### PR TITLE
Fix step icon reset

### DIFF
--- a/CV Conversion Tool.html
+++ b/CV Conversion Tool.html
@@ -78,19 +78,19 @@
                     <div id="processing-steps" class="mt-8 space-y-4">
                         <div class="flex items-center text-gray-600 processing-step">
                             <div class="w-8 h-8 rounded-full flex items-center justify-center bg-blue-100 text-blue-600 mr-4">
-                                <i class="fas fa-search" aria-hidden="true"></i>
+                                <i class="fas fa-search" aria-hidden="true" data-icon="fa-search"></i>
                             </div>
                             <span>Reading file content...</span>
                         </div>
                         <div class="flex items-center text-gray-600 processing-step">
                             <div class="w-8 h-8 rounded-full flex items-center justify-center bg-blue-100 text-blue-600 mr-4">
-                                <i class="fas fa-code" aria-hidden="true"></i>
+                                <i class="fas fa-code" aria-hidden="true" data-icon="fa-code"></i>
                             </div>
                             <span>Extracting key sections...</span>
                         </div>
                         <div class="flex items-center text-gray-600 processing-step">
                             <div class="w-8 h-8 rounded-full flex items-center justify-center bg-blue-100 text-blue-600 mr-4">
-                                <i class="fas fa-paint-brush" aria-hidden="true"></i>
+                                <i class="fas fa-paint-brush" aria-hidden="true" data-icon="fa-paint-brush"></i>
                             </div>
                             <span>Formatting to company template...</span>
                         </div>
@@ -429,7 +429,8 @@
                 processingSteps.forEach(step => {
                     step.classList.remove('text-green-600');
                     step.querySelector('div').className = 'w-8 h-8 rounded-full flex items-center justify-center bg-blue-100 text-blue-600 mr-4';
-                    step.querySelector('i').className = step.querySelector('i').className.replace('fa-check', 'fa-search');
+                    const iconElement = step.querySelector('i');
+                    iconElement.className = `fas ${iconElement.dataset.icon}`;
                 });
                 
                 // Remove file name display


### PR DESCRIPTION
## Summary
- store original step icons via `data-icon`
- restore original icon classes in `resetForm`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684695492200832d90a67474f8c77a5f