### PR TITLE
Replace webhook URL with placeholder

### DIFF
--- a/CV Conversion Tool.html
+++ b/CV Conversion Tool.html
@@ -274,7 +274,7 @@
                     const formData = new FormData();
                     formData.append('file', currentFile);
 
-                    const response = await fetch('https://hook.eu2.make.com/112mni28n0s93vceky8vztwctdf2avyc', {
+                    const response = await fetch('WEBHOOK_URL', {
                         method: 'POST',
                         body: formData
                     });

--- a/README.md
+++ b/README.md
@@ -19,3 +19,15 @@ Ces dépendances sont chargées via leur CDN et ne nécessitent pas d'installati
 
 ## Exécution ou déploiement
 Pour exécuter la page en local, ouvrez simplement le fichier HTML dans un navigateur moderne. Pour un déploiement en ligne, placez le fichier sur n'importe quel serveur web statique (par exemple GitHub Pages) car aucun backend n'est requis.
+
+## Configuration du webhook
+Avant un déploiement réel, la valeur `WEBHOOK_URL` dans `CV Conversion Tool.html`
+doit être remplacée par l'URL de votre webhook. Un petit script `configure.sh`
+est fourni pour automatiser cette étape :
+
+```sh
+WEBHOOK_URL="https://exemple.com/mon-webhook" ./configure.sh
+```
+
+Le script insère l'URL dans le fichier HTML en place afin qu'elle soit utilisée
+lors de l'envoi du fichier converti.

--- a/configure.sh
+++ b/configure.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+if [ -z "$WEBHOOK_URL" ]; then
+  echo "WEBHOOK_URL environment variable is not set" >&2
+  exit 1
+fi
+sed -i "s|WEBHOOK_URL|$WEBHOOK_URL|g" 'CV Conversion Tool.html'


### PR DESCRIPTION
## Summary
- replace hard-coded webhook URL with `WEBHOOK_URL`
- add a small `configure.sh` script to set the URL before deployment
- document how to configure the webhook URL in the README

## Testing
- `bash -n configure.sh`
- `WEBHOOK_URL='https://example.com/test' ./configure.sh`

------
https://chatgpt.com/codex/tasks/task_e_6846d3158d00832db8c2a88ac8a02343