### PR TITLE
Add webhook configuration script

### DIFF
--- a/CV Conversion Tool.html
+++ b/CV Conversion Tool.html
@@ -133,6 +133,7 @@
 
     <script>
         document.addEventListener('DOMContentLoaded', function() {
+            const WEBHOOK_URL = 'WEBHOOK_URL_PLACEHOLDER';
             const dropZone = document.getElementById('dropZone');
             const fileInput = document.getElementById('fileInput');
             const cancelBtn = document.getElementById('cancelBtn');
@@ -277,7 +278,7 @@
                     const controller = new AbortController();
                     const timeoutId = setTimeout(() => controller.abort(), 60000);
 
-                    const response = await fetch('https://hook.eu2.make.com/112mni28n0s93vceky8vztwctdf2avyc', {
+                    const response = await fetch(WEBHOOK_URL, {
                         method: 'POST',
                         body: formData,
                         signal: controller.signal

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Consultez [la documentation officielle](https://tailwindcss.com/docs/installatio
 4. Une fois le traitement terminé, un aperçu s'affiche et vous pouvez télécharger la version standardisée.
 
 ## Exécution ou déploiement
-Pour exécuter la page en local, ouvrez simplement le fichier HTML dans un navigateur moderne. Pour un déploiement en ligne, placez le fichier sur n'importe quel serveur web statique (par exemple GitHub Pages) car aucun backend n'est requis.
+Pour exécuter la page en local, ouvrez simplement le fichier HTML dans un navigateur moderne. Pour un déploiement en ligne, lancez `./configure.sh <votre_url>` afin de renseigner l'adresse du webhook puis placez le fichier sur n'importe quel serveur web statique (par exemple GitHub Pages) car aucun backend n'est requis.
 
 ## Licence
 Ce projet est distribué sous licence MIT. Voir le fichier [LICENSE](LICENSE) pour plus de détails.

--- a/configure.sh
+++ b/configure.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+if [ -z "$1" ]; then
+  echo "Usage: ./configure.sh WEBHOOK_URL" >&2
+  exit 1
+fi
+sed -i "s|WEBHOOK_URL_PLACEHOLDER|$1|" "CV Conversion Tool.html"


### PR DESCRIPTION
## Summary
- add `WEBHOOK_URL` constant in CV Conversion Tool script
- use `WEBHOOK_URL` when calling the webhook
- add `configure.sh` helper to set the URL
- update README with configuration instruction

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846d8302198832dac1f0036899d94b6